### PR TITLE
Feat: keccak256

### DIFF
--- a/eth-riscv-runtime/Cargo.toml
+++ b/eth-riscv-runtime/Cargo.toml
@@ -9,5 +9,3 @@ riscv-rt = "0.12.2"
 
 alloy-core = { version = "0.7.4", default-features = false }
 alloy-sol-types = { version = "0.7.4", default-features = false }
-
-tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -88,8 +88,7 @@ pub fn keccak256(offset: u64, size: u64) -> B256 {
             lateout("a1") second,
             lateout("a2") third,
             lateout("a3") fourth,
-            in("t0") u32::from(Syscall::Keccak256),
-            options(nostack, preserves_flags)
+            in("t0") u32::from(Syscall::Keccak256)
         );
     }
 

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -82,14 +82,14 @@ pub fn keccak256(offset: u64, size: u64) -> B256 {
     unsafe {
         asm!(
             "ecall",
-            inout("a0") data.as_ptr() => _,
-            inout("a1") size => _,
+            in("a0") offset,
+            in("a1") size,
             lateout("a0") first,
             lateout("a1") second,
             lateout("a2") third,
             lateout("a3") fourth,
             in("t0") u32::from(Syscall::Keccak256),
-            // options(nostack, preserves_flags)
+            options(nostack, preserves_flags)
         );
     }
 

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -6,7 +6,7 @@ use core::arch::asm;
 use core::panic::PanicInfo;
 use core::slice;
 pub use riscv_rt::entry;
-use alloy_core::primitives::Address;
+use alloy_core::primitives::{Address, B256};
 
 mod alloc;
 pub mod types;
@@ -71,6 +71,36 @@ pub fn revert() -> ! {
         asm!("ecall", in("t0") u32::from(Syscall::Revert));
     }
     unreachable!()
+}
+
+pub fn keccak256(offset: u64, size: u64) -> B256 {
+    let first: u64;
+    let second: u64;
+    let third: u64;
+    let fourth: u64;
+
+    unsafe {
+        asm!(
+            "ecall",
+            inout("a0") data.as_ptr() => _,
+            inout("a1") size => _,
+            lateout("a0") first,
+            lateout("a1") second,
+            lateout("a2") third,
+            lateout("a3") fourth,
+            in("t0") u32::from(Syscall::Keccak256),
+            // options(nostack, preserves_flags)
+        );
+    }
+
+    let mut bytes = [0u8; 32];
+
+    bytes[0..8].copy_from_slice(&first.to_be_bytes());
+    bytes[8..16].copy_from_slice(&second.to_be_bytes());
+    bytes[16..24].copy_from_slice(&third.to_be_bytes());
+    bytes[24..32].copy_from_slice(&fourth.to_be_bytes());
+
+    B256::from_slice(&bytes)
 }
 
 pub fn msg_sender() -> Address {

--- a/eth-riscv-runtime/src/types.rs
+++ b/eth-riscv-runtime/src/types.rs
@@ -4,7 +4,6 @@ use core::default::Default;
 use crate::*;
 
 use alloy_core::primitives::Address;
-use tiny_keccak::{Hasher, Keccak};
 
 extern crate alloc;
 use alloc::vec::Vec;
@@ -26,10 +25,10 @@ impl<K: ToBytes, V: Into<u64> + From<u64>> Mapping<K, V> {
         concatenated.extend_from_slice(&key_bytes);
         concatenated.extend_from_slice(&id_bytes);
 
-        let mut output = [0u8; 32];
-        let mut hasher = Keccak::v256();
-        hasher.update(&concatenated);
-        hasher.finalize(&mut output);
+        // Call the keccak256 syscall with the concatenated bytes
+        let offset = concatenated.as_ptr() as u64;
+        let size = concatenated.len() as u64;
+        let output = keccak256(offset, size);
 
         let mut bytes = [0u8; 8];
         bytes.copy_from_slice(&output[..8]);

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -51,7 +51,7 @@ macro_rules! syscalls {
 // t0: 3, opcode for call, args: TODO
 // t0: 4, opcode for revert, doesn't return
 // t0: 5, opcode for caller, returns an address
-// t0: 6, opcode for keccak256, a0: offset, a1: size, returns keccak256 hash
+// t0: 0x20, opcode for keccak256, a0: offset, a1: size, returns keccak256 hash
 syscalls!(
     (0, Return, "return"),
     (1, SLoad, "sload"),

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -59,5 +59,5 @@ syscalls!(
     (3, Call, "call"),
     (4, Revert, "revert"),
     (5, Caller, "caller"),
-    (6, Keccak256, "keccak256"),
+    (0x20, Keccak256, "keccak256"),
 );

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -50,6 +50,8 @@ macro_rules! syscalls {
 // t0: 2, opcode for sstore, a0: storage key, a1: storage value, returns nothing
 // t0: 3, opcode for call, args: TODO
 // t0: 4, opcode for revert, doesn't return
+// t0: 5, opcode for caller, returns an address
+// t0: 6, opcode for keccak256, a0: offset, a1: size, returns keccak256 hash
 syscalls!(
     (0, Return, "return"),
     (1, SLoad, "sload"),
@@ -57,4 +59,5 @@ syscalls!(
     (3, Call, "call"),
     (4, Revert, "revert"),
     (5, Caller, "caller"),
+    (6, Keccak256, "keccak256"),
 );

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -257,7 +257,7 @@ fn execute_riscv(
                         let third_u64 = u64::from_be_bytes(padded_bytes);
                         emu.cpu.xregs.write(12, third_u64);
                     }
-                    6 => {
+                    0x20 => {
                         // Syscall::Keccak256
                         let offset: u64 = emu.cpu.xregs.read(10);
                         let size: u64 = emu.cpu.xregs.read(11);


### PR DESCRIPTION
Quick resolve for `KECCAK256` implementation related to https://github.com/r55-eth/r55/issues/4

`cargo run` is passed correctly, but not too sure about this implementation

cc: @leonardoalt 