### PR TITLE
Add opcodes for `msg.*`

### DIFF
--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -81,7 +81,7 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Generate the call method implementation
     let call_method = quote! {
         use alloy_sol_types::SolValue;
-        use eth_riscv_runtime::{revert, msg_sender, msg_value, return_riscv, slice_from_raw_parts, Contract};
+        use eth_riscv_runtime::{revert, msg_sender, msg_value, msg_sig, return_riscv, slice_from_raw_parts, Contract};
 
         impl Contract for #struct_name {
             fn call(&self) {

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -94,11 +94,7 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         impl Contract for #struct_name {
             fn call(&self) {
-                let address: usize = 0x8000_0000;
-                let length = unsafe { slice_from_raw_parts(address, 8) };
-                let length = u64::from_le_bytes([length[0], length[1], length[2], length[3], length[4], length[5], length[6], length[7]]) as usize;
-                let calldata = unsafe { slice_from_raw_parts(address + 8, length) };
-                self.call_with_data(calldata);
+                self.call_with_data(&msg_data());
             }
 
             fn call_with_data(&self, calldata: &[u8]) {

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -81,7 +81,7 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Generate the call method implementation
     let call_method = quote! {
         use alloy_sol_types::SolValue;
-        use eth_riscv_runtime::{revert, msg_sender, msg_value, msg_sig, return_riscv, slice_from_raw_parts, Contract};
+        use eth_riscv_runtime::{revert, msg_sender, msg_value, msg_sig, msg_data, return_riscv, slice_from_raw_parts, Contract};
 
         impl Contract for #struct_name {
             fn call(&self) {

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -81,7 +81,7 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Generate the call method implementation
     let call_method = quote! {
         use alloy_sol_types::SolValue;
-        use eth_riscv_runtime::{revert, msg_sender, return_riscv, slice_from_raw_parts, Contract};
+        use eth_riscv_runtime::{revert, msg_sender, msg_value, return_riscv, slice_from_raw_parts, Contract};
 
         impl Contract for #struct_name {
             fn call(&self) {

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -3,7 +3,7 @@
 
 use core::default::Default;
 
-use contract_derive::contract;
+use contract_derive::{contract, payable};
 use eth_riscv_runtime::types::Mapping;
 
 use alloy_core::primitives::{Address, address, U256};
@@ -34,12 +34,10 @@ impl ERC20 {
         self.balance.write(to, to_balance + value);
     }
 
+    #[payable]
     pub fn mint(&self, to: Address, value: u64) {
         let owner = msg_sender();
         if owner != address!("0000000000000000000000000000000000000007") {
-            revert();
-        }
-        if msg_value() != U256::from(0) {
             revert();
         }
         if msg_sig() != [2, 0, 0, 0] {

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -16,9 +16,6 @@ pub struct ERC20 {
 #[contract]
 impl ERC20 {
     pub fn balance_of(&self, owner: Address) -> u64 {
-        if msg_data()[0] != 0x0 {
-            revert();
-        }
         self.balance.read(owner)
     }
 
@@ -38,9 +35,6 @@ impl ERC20 {
     pub fn mint(&self, to: Address, value: u64) {
         let owner = msg_sender();
         if owner != address!("0000000000000000000000000000000000000007") {
-            revert();
-        }
-        if msg_sig() != [2, 0, 0, 0] {
             revert();
         }
 

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -6,7 +6,7 @@ use core::default::Default;
 use contract_derive::contract;
 use eth_riscv_runtime::types::Mapping;
 
-use alloy_core::primitives::{Address, address};
+use alloy_core::primitives::{Address, address, U256};
 
 #[derive(Default)]
 pub struct ERC20 {
@@ -34,6 +34,9 @@ impl ERC20 {
     pub fn mint(&self, to: Address, value: u64) {
         let owner = msg_sender();
         if owner != address!("0000000000000000000000000000000000000007") {
+            revert();
+        }
+        if msg_value() != U256::from(0) {
             revert();
         }
 

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -16,6 +16,9 @@ pub struct ERC20 {
 #[contract]
 impl ERC20 {
     pub fn balance_of(&self, owner: Address) -> u64 {
+        if msg_data()[0] != 0x0 {
+            revert();
+        }
         self.balance.read(owner)
     }
 

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -39,6 +39,9 @@ impl ERC20 {
         if msg_value() != U256::from(0) {
             revert();
         }
+        if msg_sig() != [2, 0, 0, 0] {
+            revert();
+        }
 
         let to_balance = self.balance.read(to);
         self.balance.write(to, to_balance + value);

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -7,8 +7,6 @@ use core::arch::asm;
 use core::panic::PanicInfo;
 use core::slice;
 pub use riscv_rt::entry;
-extern crate alloc as std_alloc;
-use std_alloc::vec::Vec;
 
 mod alloc;
 pub mod types;
@@ -126,7 +124,7 @@ pub fn msg_value() -> U256 {
     let third: u64;
     let fourth: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u8::from(Syscall::CALLVALUE));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u8::from(Syscall::CallValue));
     }
     U256::from_limbs([first, second, third, fourth])
 }
@@ -136,11 +134,10 @@ pub fn msg_sig() -> [u8; 4] {
     sig.try_into().unwrap()
 }
 
-pub fn msg_data() -> Vec<u8> {
+pub fn msg_data() -> &'static [u8] {
     let length = unsafe { slice_from_raw_parts(CALLDATA_ADDRESS, 8) };
     let length = u64::from_le_bytes([length[0], length[1], length[2], length[3], length[4], length[5], length[6], length[7]]) as usize;
-    let calldata = unsafe { slice_from_raw_parts(CALLDATA_ADDRESS + 8, length) };
-    calldata.to_vec()
+    unsafe { slice_from_raw_parts(CALLDATA_ADDRESS + 8, length) }
 }
 
 #[allow(non_snake_case)]

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -43,7 +43,7 @@ use eth_riscv_syscalls::Syscall;
 
 pub fn return_riscv(addr: u64, offset: u64) -> ! {
     unsafe {
-        asm!("ecall", in("a0") addr, in("a1") offset, in("t0") u64::from(Syscall::Return));
+        asm!("ecall", in("a0") addr, in("a1") offset, in("t0") u8::from(Syscall::Return));
     }
     unreachable!()
 }
@@ -51,26 +51,26 @@ pub fn return_riscv(addr: u64, offset: u64) -> ! {
 pub fn sload(key: u64) -> u64 {
     let value: u64;
     unsafe {
-        asm!("ecall", lateout("a0") value, in("a0") key, in("t0") u64::from(Syscall::SLoad));
+        asm!("ecall", lateout("a0") value, in("a0") key, in("t0") u8::from(Syscall::SLoad));
     }
     value
 }
 
 pub fn sstore(key: u64, value: u64) {
     unsafe {
-        asm!("ecall", in("a0") key, in("a1") value, in("t0") u64::from(Syscall::SStore));
+        asm!("ecall", in("a0") key, in("a1") value, in("t0") u8::from(Syscall::SStore));
     }
 }
 
 pub fn call(addr: u64, value: u64, in_mem: u64, in_size: u64, out_mem: u64, out_size: u64) {
     unsafe {
-        asm!("ecall", in("a0") addr, in("a1") value, in("a2") in_mem, in("a3") in_size, in("a4") out_mem, in("a5") out_size, in("t0") u64::from(Syscall::Call));
+        asm!("ecall", in("a0") addr, in("a1") value, in("a2") in_mem, in("a3") in_size, in("a4") out_mem, in("a5") out_size, in("t0") u8::from(Syscall::Call));
     }
 }
 
 pub fn revert() -> ! {
     unsafe {
-        asm!("ecall", in("t0") u64::from(Syscall::Revert));
+        asm!("ecall", in("t0") u8::from(Syscall::Revert));
     }
     unreachable!()
 }
@@ -90,7 +90,7 @@ pub fn keccak256(offset: u64, size: u64) -> B256 {
             lateout("a1") second,
             lateout("a2") third,
             lateout("a3") fourth,
-            in("t0") u64::from(Syscall::Keccak256)
+            in("t0") u8::from(Syscall::Keccak256)
         );
     }
 
@@ -109,7 +109,7 @@ pub fn msg_sender() -> Address {
     let second: u64;
     let third: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, in("t0") u64::from(Syscall::Caller));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, in("t0") u8::from(Syscall::Caller));
     }
     let mut bytes = [0u8; 20];
     bytes[0..8].copy_from_slice(&first.to_be_bytes());
@@ -124,7 +124,7 @@ pub fn msg_value() -> U256 {
     let third: u64;
     let fourth: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u64::from(Syscall::CALLVALUE));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u8::from(Syscall::CALLVALUE));
     }
     U256::from_limbs([first, second, third, fourth])
 }
@@ -133,7 +133,7 @@ pub fn msg_sig() -> [u8; 4] {
     let first: u64;
     let offset: u64 = 0;
     unsafe {
-        asm!("ecall", lateout("a0") first, in("a0") offset, in("t0") u64::from(Syscall::CALLDATALOAD));
+        asm!("ecall", lateout("a0") first, in("a0") offset, in("t0") u8::from(Syscall::CALLDATALOAD));
     }
     let mut bytes = [0u8; 4];
     bytes.copy_from_slice(&first.to_le_bytes()[0..4]);
@@ -144,7 +144,7 @@ pub fn msg_data() -> Vec<u8> {
     // Get the size of the call data
     let size: u64;
     unsafe {
-        asm!("ecall", lateout("a0") size, in("t0") u64::from(Syscall::CALLDATASIZE));
+        asm!("ecall", lateout("a0") size, in("t0") u8::from(Syscall::CALLDATASIZE));
     }
     // Load the call data
     let mut call_data = Vec::with_capacity(size as usize);
@@ -155,7 +155,7 @@ pub fn msg_data() -> Vec<u8> {
         let fourth: u64;
         // Load 32 bytes of call data
         unsafe {
-        asm!("ecall", in("a0") offset, lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u64::from(Syscall::CALLDATALOAD));
+        asm!("ecall", in("a0") offset, lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u8::from(Syscall::CALLDATALOAD));
         }
         let mut bytes = [0u8; 32];
         bytes[0..8].copy_from_slice(&first.to_le_bytes());

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -88,7 +88,7 @@ pub fn keccak256(offset: u64, size: u64) -> B256 {
             lateout("a1") second,
             lateout("a2") third,
             lateout("a3") fourth,
-            in("t0") u32::from(Syscall::Keccak256)
+            in("t0") u64::from(Syscall::Keccak256)
         );
     }
 
@@ -125,6 +125,17 @@ pub fn msg_value() -> U256 {
         asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u64::from(Syscall::CALLVALUE));
     }
     U256::from_limbs([first, second, third, fourth])
+}
+
+pub fn msg_sig() -> [u8; 4] {
+    let first: u64;
+    let offset: u64 = 0;
+    unsafe {
+        asm!("ecall", lateout("a0") first, in("a0") offset, in("t0") u64::from(Syscall::CALLDATALOAD));
+    }
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&first.to_le_bytes()[0..4]);
+    bytes
 }
 
 #[allow(non_snake_case)]

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -2,11 +2,11 @@
 #![no_main]
 #![feature(alloc_error_handler, maybe_uninit_write_slice, round_char_boundary)]
 
+use alloy_core::primitives::{Address, U256, B256};
 use core::arch::asm;
 use core::panic::PanicInfo;
 use core::slice;
 pub use riscv_rt::entry;
-use alloy_core::primitives::{Address, B256};
 
 mod alloc;
 pub mod types;
@@ -41,7 +41,7 @@ use eth_riscv_syscalls::Syscall;
 
 pub fn return_riscv(addr: u64, offset: u64) -> ! {
     unsafe {
-        asm!("ecall", in("a0") addr, in("a1") offset, in("t0") u32::from(Syscall::Return));
+        asm!("ecall", in("a0") addr, in("a1") offset, in("t0") u64::from(Syscall::Return));
     }
     unreachable!()
 }
@@ -49,26 +49,26 @@ pub fn return_riscv(addr: u64, offset: u64) -> ! {
 pub fn sload(key: u64) -> u64 {
     let value: u64;
     unsafe {
-        asm!("ecall", lateout("a0") value, in("a0") key, in("t0") u32::from(Syscall::SLoad));
+        asm!("ecall", lateout("a0") value, in("a0") key, in("t0") u64::from(Syscall::SLoad));
     }
     value
 }
 
 pub fn sstore(key: u64, value: u64) {
     unsafe {
-        asm!("ecall", in("a0") key, in("a1") value, in("t0") u32::from(Syscall::SStore));
+        asm!("ecall", in("a0") key, in("a1") value, in("t0") u64::from(Syscall::SStore));
     }
 }
 
 pub fn call(addr: u64, value: u64, in_mem: u64, in_size: u64, out_mem: u64, out_size: u64) {
     unsafe {
-        asm!("ecall", in("a0") addr, in("a1") value, in("a2") in_mem, in("a3") in_size, in("a4") out_mem, in("a5") out_size, in("t0") u32::from(Syscall::Call));
+        asm!("ecall", in("a0") addr, in("a1") value, in("a2") in_mem, in("a3") in_size, in("a4") out_mem, in("a5") out_size, in("t0") u64::from(Syscall::Call));
     }
 }
 
 pub fn revert() -> ! {
     unsafe {
-        asm!("ecall", in("t0") u32::from(Syscall::Revert));
+        asm!("ecall", in("t0") u64::from(Syscall::Revert));
     }
     unreachable!()
 }
@@ -107,13 +107,24 @@ pub fn msg_sender() -> Address {
     let second: u64;
     let third: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, in("t0") u32::from(Syscall::Caller));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, in("t0") u64::from(Syscall::Caller));
     }
     let mut bytes = [0u8; 20];
     bytes[0..8].copy_from_slice(&first.to_be_bytes());
     bytes[8..16].copy_from_slice(&second.to_be_bytes());
     bytes[16..20].copy_from_slice(&third.to_be_bytes()[..4]);
     Address::from_slice(&bytes)
+}
+
+pub fn msg_value() -> U256 {
+    let first: u64;
+    let second: u64;
+    let third: u64;
+    let fourth: u64;
+    unsafe {
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u64::from(Syscall::CALLVALUE));
+    }
+    U256::from_limbs([first, second, third, fourth])
 }
 
 #[allow(non_snake_case)]

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -61,5 +61,6 @@ syscalls!(
     (5, Caller, "caller"),
     (0x20, Keccak256, "keccak256"),
     (34, CALLVALUE, "callvalue"),
-    (35, CALLDATALOAD, "calldataload")
+    (35, CALLDATALOAD, "calldataload"),
+    (36, CALLDATASIZE, "calldatasize")
 );

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -52,6 +52,7 @@ macro_rules! syscalls {
 // t0: 4, opcode for revert, doesn't return
 // t0: 5, opcode for caller, returns an address
 // t0: 0x20, opcode for keccak256, a0: offset, a1: size, returns keccak256 hash
+// t0: 0x34, opcode for callvalue, a0: first limb, a1: second limb, a2: third limb, a3: fourth limb, returns 256-bit value
 syscalls!(
     (0, Return, "return"),
     (1, SLoad, "sload"),
@@ -60,5 +61,5 @@ syscalls!(
     (4, Revert, "revert"),
     (5, Caller, "caller"),
     (0x20, Keccak256, "keccak256"),
-    (34, CALLVALUE, "callvalue"),
+    (0x34, CallValue, "callvalue"),
 );

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -3,7 +3,7 @@
 macro_rules! syscalls {
     ($(($num:expr, $identifier:ident, $name:expr)),* $(,)?) => {
         #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-        #[repr(u64)]
+        #[repr(u8)]
         pub enum Syscall {
             $($identifier = $num),*
         }
@@ -26,15 +26,15 @@ macro_rules! syscalls {
             }
         }
 
-        impl From<Syscall> for u64 {
+        impl From<Syscall> for u8 {
             fn from(syscall: Syscall) -> Self {
                 syscall as Self
             }
         }
 
-        impl core::convert::TryFrom<u64> for Syscall {
+        impl core::convert::TryFrom<u8> for Syscall {
             type Error = ();
-            fn try_from(value: u64) -> Result<Self, Self::Error> {
+            fn try_from(value: u8) -> Result<Self, Self::Error> {
                 match value {
                     $($num => Ok(Syscall::$identifier)),*,
                     _ => Err(()),

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -61,6 +61,4 @@ syscalls!(
     (5, Caller, "caller"),
     (0x20, Keccak256, "keccak256"),
     (34, CALLVALUE, "callvalue"),
-    (35, CALLDATALOAD, "calldataload"),
-    (36, CALLDATASIZE, "calldatasize")
 );

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -3,7 +3,7 @@
 macro_rules! syscalls {
     ($(($num:expr, $identifier:ident, $name:expr)),* $(,)?) => {
         #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-        #[repr(u32)]
+        #[repr(u64)]
         pub enum Syscall {
             $($identifier = $num),*
         }
@@ -26,15 +26,15 @@ macro_rules! syscalls {
             }
         }
 
-        impl From<Syscall> for u32 {
+        impl From<Syscall> for u64 {
             fn from(syscall: Syscall) -> Self {
                 syscall as Self
             }
         }
 
-        impl core::convert::TryFrom<u32> for Syscall {
+        impl core::convert::TryFrom<u64> for Syscall {
             type Error = ();
-            fn try_from(value: u32) -> Result<Self, Self::Error> {
+            fn try_from(value: u64) -> Result<Self, Self::Error> {
                 match value {
                     $($num => Ok(Syscall::$identifier)),*,
                     _ => Err(()),
@@ -60,4 +60,5 @@ syscalls!(
     (4, Revert, "revert"),
     (5, Caller, "caller"),
     (0x20, Keccak256, "keccak256"),
+    (34, CALLVALUE, "callvalue") 
 );

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -60,5 +60,6 @@ syscalls!(
     (4, Revert, "revert"),
     (5, Caller, "caller"),
     (0x20, Keccak256, "keccak256"),
-    (34, CALLVALUE, "callvalue") 
+    (34, CALLVALUE, "callvalue"),
+    (35, CALLDATALOAD, "calldataload")
 );

--- a/r55/Cargo.toml
+++ b/r55/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 revm = "9.0.0"
 rvemu = { git = "https://github.com/lvella/rvemu.git" }
 eth-riscv-interpreter = { git = "https://github.com/leonardoalt/r55" }
+eth-riscv-syscalls = { path = "../eth-riscv-syscalls" }
 alloy-core = "0.7.4"
 alloy-sol-types = "0.7.4"
 

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -154,7 +154,7 @@ fn execute_riscv(
         match run_result {
             Err(Exception::EnvironmentCallFromMMode) => {
                 let t0: u64 = emu.cpu.xregs.read(5);
-                match Syscall::try_from(t0) {
+                match Syscall::try_from(t0 as u8) {
                     Ok(Syscall::Return) => {
                         let ret_offset: u64 = emu.cpu.xregs.read(10);
                         let ret_size: u64 = emu.cpu.xregs.read(11);

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -281,7 +281,7 @@ fn execute_riscv(
                             .xregs
                             .write(13, u64::from_le_bytes(hash[24..32].try_into().unwrap()));
                     }
-                    Ok(Syscall::CALLVALUE) => {
+                    Ok(Syscall::CallValue) => {
                         let value = interpreter.contract.call_value;
                         let limbs = value.into_limbs();
                         emu.cpu.xregs.write(10, limbs[0]);

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -283,6 +283,17 @@ fn execute_riscv(
                         emu.cpu.xregs.write(12, limbs[2]);
                         emu.cpu.xregs.write(13, limbs[3]);
                     }
+                    Ok(Syscall::CALLDATALOAD) => {
+                        let offset: u64 = emu.cpu.xregs.read(10);
+                        // We only need 32 bytes of call data start from offset
+                        let call_data = interpreter.contract.input.get(offset as usize..(offset + 32) as usize).unwrap();
+                        println!("call_data: {:?}", call_data);
+                        // TODO: handle case where call_data is less than 32 bytes
+                        emu.cpu.xregs.write(10, u64::from_le_bytes(call_data[0..8].try_into().unwrap()));
+                        emu.cpu.xregs.write(11, u64::from_le_bytes(call_data[8..16].try_into().unwrap()));
+                        emu.cpu.xregs.write(12, u64::from_le_bytes(call_data[16..24].try_into().unwrap()));
+                        emu.cpu.xregs.write(13, u64::from_le_bytes(call_data[24..32].try_into().unwrap()));
+                    }
                     _ => {
                         println!("Unhandled syscall: {:?}", t0);
                         return return_revert(interpreter);

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -289,37 +289,6 @@ fn execute_riscv(
                         emu.cpu.xregs.write(12, limbs[2]);
                         emu.cpu.xregs.write(13, limbs[3]);
                     }
-                    Ok(Syscall::CALLDATALOAD) => {
-                        let offset: u64 = emu.cpu.xregs.read(10);
-                        let mut call_data = [0u8; 32];
-                        // We only need 32 bytes of call data, starting from offset
-                        if let Some(data) = interpreter
-                            .contract
-                            .input
-                            .get(offset as usize..(offset + 32) as usize)
-                        {
-                            call_data[..data.len()].copy_from_slice(data);
-                        }
-
-                        emu.cpu
-                            .xregs
-                            .write(10, u64::from_le_bytes(call_data[0..8].try_into().unwrap()));
-                        emu.cpu
-                            .xregs
-                            .write(11, u64::from_le_bytes(call_data[8..16].try_into().unwrap()));
-                        emu.cpu.xregs.write(
-                            12,
-                            u64::from_le_bytes(call_data[16..24].try_into().unwrap()),
-                        );
-                        emu.cpu.xregs.write(
-                            13,
-                            u64::from_le_bytes(call_data[24..32].try_into().unwrap()),
-                        );
-                    }
-                    Ok(Syscall::CALLDATASIZE) => {
-                        let size = interpreter.contract.input.len();
-                        emu.cpu.xregs.write(10, size as u64);
-                    }
                     _ => {
                         println!("Unhandled syscall: {:?}", t0);
                         return return_revert(interpreter);


### PR DESCRIPTION
Related to #4 

Adds `msg.value`. `msg.sig` and `msg.data` with light checks in the contract

Also uses enum to pattern match syscalls.