### PR TITLE
Feat: syscalls enhance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,10 @@
 
 resolver = "2"
 
-members = [ "eth-riscv-interpreter",
-    "eth-riscv-syscalls", "r55",
-]
+members = ["eth-riscv-interpreter", "eth-riscv-syscalls", "r55"]
+default-members = ["eth-riscv-interpreter", "eth-riscv-syscalls", "r55"]
 
-exclude = [ "contract-derive", "erc20", "eth-riscv-runtime" ]
+exclude = ["contract-derive", "erc20", "eth-riscv-runtime"]
 
 [workspace.package]
 version = "0.1.0"
@@ -15,3 +14,5 @@ license = "Apache 2.0"
 repository = "https://github.com/leonardoalt/r5"
 
 [workspace.dependencies]
+eth-riscv-interpreter = { path = "eth-riscv-interpreter" }
+eth-riscv-syscalls = { path = "eth-riscv-syscalls" }

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -41,7 +41,7 @@ use eth_riscv_syscalls::Syscall;
 
 pub fn return_riscv(addr: u64, offset: u64) -> ! {
     unsafe {
-        asm!("ecall", in("a0") addr, in("a1") offset, in("t0") u32::from(Syscall::Return));
+        asm!("ecall", in("a0") addr, in("a1") offset, in("t0") u8::from(Syscall::Return));
     }
     unreachable!()
 }
@@ -49,26 +49,26 @@ pub fn return_riscv(addr: u64, offset: u64) -> ! {
 pub fn sload(key: u64) -> u64 {
     let value: u64;
     unsafe {
-        asm!("ecall", lateout("a0") value, in("a0") key, in("t0") u32::from(Syscall::SLoad));
+        asm!("ecall", lateout("a0") value, in("a0") key, in("t0") u8::from(Syscall::SLoad));
     }
     value
 }
 
 pub fn sstore(key: u64, value: u64) {
     unsafe {
-        asm!("ecall", in("a0") key, in("a1") value, in("t0") u32::from(Syscall::SStore));
+        asm!("ecall", in("a0") key, in("a1") value, in("t0") u8::from(Syscall::SStore));
     }
 }
 
 pub fn call(addr: u64, value: u64, in_mem: u64, in_size: u64, out_mem: u64, out_size: u64) {
     unsafe {
-        asm!("ecall", in("a0") addr, in("a1") value, in("a2") in_mem, in("a3") in_size, in("a4") out_mem, in("a5") out_size, in("t0") u32::from(Syscall::Call));
+        asm!("ecall", in("a0") addr, in("a1") value, in("a2") in_mem, in("a3") in_size, in("a4") out_mem, in("a5") out_size, in("t0") u8::from(Syscall::Call));
     }
 }
 
 pub fn revert() -> ! {
     unsafe {
-        asm!("ecall", in("t0") u32::from(Syscall::Revert));
+        asm!("ecall", in("t0") u8::from(Syscall::Revert));
     }
     unreachable!()
 }
@@ -88,7 +88,7 @@ pub fn keccak256(offset: u64, size: u64) -> B256 {
             lateout("a1") second,
             lateout("a2") third,
             lateout("a3") fourth,
-            in("t0") u32::from(Syscall::Keccak256)
+            in("t0") u8::from(Syscall::Keccak256)
         );
     }
 
@@ -107,7 +107,7 @@ pub fn msg_sender() -> Address {
     let second: u64;
     let third: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, in("t0") u32::from(Syscall::Caller));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, in("t0") u8::from(Syscall::Caller));
     }
     let mut bytes = [0u8; 20];
     bytes[0..8].copy_from_slice(&first.to_be_bytes());

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -3,7 +3,7 @@
 macro_rules! syscalls {
     ($(($num:expr, $identifier:ident, $name:expr)),* $(,)?) => {
         #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-        #[repr(u32)]
+        #[repr(u8)]
         pub enum Syscall {
             $($identifier = $num),*
         }
@@ -26,15 +26,15 @@ macro_rules! syscalls {
             }
         }
 
-        impl From<Syscall> for u32 {
+        impl From<Syscall> for u8 {
             fn from(syscall: Syscall) -> Self {
                 syscall as Self
             }
         }
 
-        impl core::convert::TryFrom<u32> for Syscall {
+        impl core::convert::TryFrom<u8> for Syscall {
             type Error = ();
-            fn try_from(value: u32) -> Result<Self, Self::Error> {
+            fn try_from(value: u8) -> Result<Self, Self::Error> {
                 match value {
                     $($num => Ok(Syscall::$identifier)),*,
                     _ => Err(()),

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -45,19 +45,19 @@ macro_rules! syscalls {
 }
 
 // Generate `Syscall` enum with supported syscalls and their numbers.
-// t0: 0, opcode for return, a0: memory address of data, a1: length of data, in bytes, doesn't return
-// t0: 1, opcode for sload, a0: storage key, returns 64-bit value in a0
-// t0: 2, opcode for sstore, a0: storage key, a1: storage value, returns nothing
-// t0: 3, opcode for call, args: TODO
-// t0: 4, opcode for revert, doesn't return
-// t0: 5, opcode for caller, returns an address
 // t0: 0x20, opcode for keccak256, a0: offset, a1: size, returns keccak256 hash
+// t0: 0x33, opcode for caller, returns an address
+// t0: 0x54, opcode for sload, a0: storage key, returns 64-bit value in a0
+// t0: 0x55, opcode for sstore, a0: storage key, a1: storage value, returns nothing
+// t0: 0xf1, opcode for call, args: TODO
+// t0: 0xf3, opcode for return, a0: memory address of data, a1: length of data in bytes, doesn't return
+// t0: 0xfd, opcode for revert, doesn't return
 syscalls!(
-    (0, Return, "return"),
-    (1, SLoad, "sload"),
-    (2, SStore, "sstore"),
-    (3, Call, "call"),
-    (4, Revert, "revert"),
-    (5, Caller, "caller"),
     (0x20, Keccak256, "keccak256"),
+    (0x33, Caller, "caller"),
+    (0x54, SLoad, "sload"),
+    (0x55, SStore, "sstore"),
+    (0xf1, Call, "call"),
+    (0xf3, Return, "return"),
+    (0xfd, Revert, "revert")
 );

--- a/r55/Cargo.toml
+++ b/r55/Cargo.toml
@@ -7,9 +7,11 @@ repository.workspace = true
 
 [dependencies]
 #revm = { git = "https://github.com/r0qs/revm" }
+eth-riscv-interpreter.workspace = true
+eth-riscv-syscalls.workspace = true
+
 revm = "9.0.0"
 rvemu = { git = "https://github.com/lvella/rvemu.git" }
-eth-riscv-interpreter = { git = "https://github.com/leonardoalt/r55" }
 alloy-core = "0.7.4"
 alloy-sol-types = "0.7.4"
 

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -1,5 +1,6 @@
 use alloy_core::primitives::Keccak256;
 use eth_riscv_interpreter::setup_from_elf;
+use eth_riscv_syscalls::Syscall;
 use revm::{
     handler::register::EvmHandler,
     interpreter::{
@@ -132,7 +133,9 @@ fn execute_riscv(
     let emu = &mut rvemu.emu;
     let returned_data_destiny = &mut rvemu.returned_data_destiny;
     if let Some(destiny) = std::mem::take(returned_data_destiny) {
-        let data = emu.cpu.bus.get_dram_slice(destiny).unwrap();
+        let data = emu.cpu.bus
+        	.get_dram_slice(destiny)
+        	.unwrap_or_else(|e| panic!("Unable to get destiny dram slice ({e:?})"));
         data.copy_from_slice(shared_memory.slice(0, data.len()))
     }
 
@@ -153,9 +156,14 @@ fn execute_riscv(
         match run_result {
             Err(Exception::EnvironmentCallFromMMode) => {
                 let t0: u64 = emu.cpu.xregs.read(5);
-                match t0 {
-                    0 => {
-                        // Syscall::Return
+
+                let Ok(syscall) = Syscall::try_from(t0 as u8) else {
+	                println!("Unhandled syscall: {:?}", t0);
+	                return return_revert(interpreter);
+                };
+
+                match syscall {
+                    Syscall::Return => {
                         let ret_offset: u64 = emu.cpu.xregs.read(10);
                         let ret_size: u64 = emu.cpu.xregs.read(11);
                         let data_bytes = if ret_size != 0 {
@@ -174,8 +182,7 @@ fn execute_riscv(
                             },
                         };
                     }
-                    1 => {
-                        // Syscall:SLoad
+                    Syscall::SLoad => {
                         let key: u64 = emu.cpu.xregs.read(10);
                         match host.sload(interpreter.contract.target_address, U256::from(key)) {
                             Some((value, _is_cold)) => {
@@ -186,8 +193,7 @@ fn execute_riscv(
                             }
                         }
                     }
-                    2 => {
-                        // Syscall::SStore
+                    Syscall::SStore => {
                         let key: u64 = emu.cpu.xregs.read(10);
                         let value: u64 = emu.cpu.xregs.read(11);
                         host.sstore(
@@ -196,8 +202,7 @@ fn execute_riscv(
                             U256::from(value),
                         );
                     }
-                    3 => {
-                        // Syscall::Call
+                    Syscall::Call => {
                         let a0: u64 = emu.cpu.xregs.read(10);
                         let address =
                             Address::from_slice(emu.cpu.bus.get_dram_slice(a0..(a0 + 20)).unwrap());
@@ -233,8 +238,7 @@ fn execute_riscv(
                             }),
                         };
                     }
-                    4 => {
-                        // Syscall::Revert
+                    Syscall::Revert => {
                         return InterpreterAction::Return {
                             result: InterpreterResult {
                                 result: InstructionResult::Revert,
@@ -243,30 +247,26 @@ fn execute_riscv(
                             },
                         };
                     }
-                    5 => {
-                        // Syscall::Caller
+                     Syscall::Caller => {
                         let caller = interpreter.contract.caller;
                         // Break address into 3 u64s and write to registers
                         let caller_bytes = caller.as_slice();
                         let first_u64 = u64::from_be_bytes(caller_bytes[0..8].try_into().unwrap());
                         emu.cpu.xregs.write(10, first_u64);
-                        let second_u64 = u64::from_be_bytes(caller_bytes[8..16].try_into().unwrap());
+                        let second_u64 =
+                            u64::from_be_bytes(caller_bytes[8..16].try_into().unwrap());
                         emu.cpu.xregs.write(11, second_u64);
                         let mut padded_bytes = [0u8; 8];
                         padded_bytes[..4].copy_from_slice(&caller_bytes[16..20]);
                         let third_u64 = u64::from_be_bytes(padded_bytes);
                         emu.cpu.xregs.write(12, third_u64);
                     }
-                    0x20 => {
-                        // Syscall::Keccak256
+                    Syscall::Keccak256 => {
                         let offset: u64 = emu.cpu.xregs.read(10);
                         let size: u64 = emu.cpu.xregs.read(11);
 
                         let data_bytes = if size != 0 {
-                            emu.cpu
-                                .bus
-                                .get_dram_slice(offset..(offset + size))
-                                .unwrap()
+                            emu.cpu.bus.get_dram_slice(offset..(offset + size)).unwrap()
                         } else {
                             &mut []
                         };
@@ -276,14 +276,18 @@ fn execute_riscv(
                         let hash: [u8; 32] = hasher.finalize().into();
 
                         // Write the hash to the emulator's registers
-                        emu.cpu.xregs.write(10, u64::from_le_bytes(hash[0..8].try_into().unwrap()));
-                        emu.cpu.xregs.write(11, u64::from_le_bytes(hash[8..16].try_into().unwrap()));
-                        emu.cpu.xregs.write(12, u64::from_le_bytes(hash[16..24].try_into().unwrap()));
-                        emu.cpu.xregs.write(13, u64::from_le_bytes(hash[24..32].try_into().unwrap()));
-                    }
-                    _ => {
-                        println!("Unhandled syscall: {:?}", t0);
-                        return return_revert(interpreter);
+                        emu.cpu
+                            .xregs
+                            .write(10, u64::from_le_bytes(hash[0..8].try_into().unwrap()));
+                        emu.cpu
+                            .xregs
+                            .write(11, u64::from_le_bytes(hash[8..16].try_into().unwrap()));
+                        emu.cpu
+                            .xregs
+                            .write(12, u64::from_le_bytes(hash[16..24].try_into().unwrap()));
+                        emu.cpu
+                            .xregs
+                            .write(13, u64::from_le_bytes(hash[24..32].try_into().unwrap()));
                     }
                 }
             }


### PR DESCRIPTION
Related to https://github.com/r55-eth/r55/issues/4

Resolves: Clean up the syscalls ids, use EVM opcode values for clarity and guidelines

Also add
- `u8` syscall ids instead of `u32`
- RISC-V DRAM slice getter extracted into a function