### PR TITLE
feat: add block.* opcodes

### DIFF
--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -90,7 +90,7 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Generate the call method implementation
     let call_method = quote! {
         use alloy_sol_types::SolValue;
-        use eth_riscv_runtime::{revert, msg_sender, msg_value, msg_sig, msg_data, return_riscv, slice_from_raw_parts, Contract};
+        use eth_riscv_runtime::*;
 
         impl Contract for #struct_name {
             fn call(&self) {

--- a/eth-riscv-runtime/src/block.rs
+++ b/eth-riscv-runtime/src/block.rs
@@ -9,7 +9,7 @@ pub fn timestamp() -> U256 {
     let third: u64;
     let fourth: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u32::from(Syscall::Timestamp));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u8::from(Syscall::Timestamp));
     }
     U256::from_limbs([first, second, third, fourth])
 }
@@ -21,7 +21,7 @@ pub fn base_fee() -> U256 {
     let third: u64;
     let fourth: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u32::from(Syscall::BaseFee));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u8::from(Syscall::BaseFee));
     }
     U256::from_limbs([first, second, third, fourth])
 }
@@ -30,7 +30,7 @@ pub fn base_fee() -> U256 {
 pub fn chain_id() -> u64 {
     let id: u64;
     unsafe {
-        asm!("ecall", lateout("a0") id, in("t0") u32::from(Syscall::ChainId));
+        asm!("ecall", lateout("a0") id, in("t0") u8::from(Syscall::ChainId));
     }
     id
 }
@@ -42,7 +42,7 @@ pub fn gas_limit() -> U256 {
     let third: u64;
     let fourth: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u32::from(Syscall::GasLimit));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u8::from(Syscall::GasLimit));
     }
     U256::from_limbs([first, second, third, fourth])
 }
@@ -54,7 +54,7 @@ pub fn number() -> U256 {
     let third: u64;
     let fourth: u64;
     unsafe {
-        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u32::from(Syscall::Number));
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u8::from(Syscall::Number));
     }
     U256::from_limbs([first, second, third, fourth])
 }

--- a/eth-riscv-runtime/src/block.rs
+++ b/eth-riscv-runtime/src/block.rs
@@ -1,0 +1,60 @@
+use alloy_core::primitives::U256;
+use eth_riscv_syscalls::Syscall;
+use core::arch::asm;
+
+// Returns current block timestamp in seconds since Unix epoch
+pub fn timestamp() -> U256 {
+    let first: u64;
+    let second: u64;
+    let third: u64;
+    let fourth: u64;
+    unsafe {
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u32::from(Syscall::Timestamp));
+    }
+    U256::from_limbs([first, second, third, fourth])
+}
+
+// Returns current block base fee (EIP-3198 and EIP-1559)
+pub fn base_fee() -> U256 {
+    let first: u64;
+    let second: u64;
+    let third: u64;
+    let fourth: u64;
+    unsafe {
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u32::from(Syscall::BaseFee));
+    }
+    U256::from_limbs([first, second, third, fourth])
+}
+
+// Returns current chain ID
+pub fn chain_id() -> u64 {
+    let id: u64;
+    unsafe {
+        asm!("ecall", lateout("a0") id, in("t0") u32::from(Syscall::ChainId));
+    }
+    id
+}
+
+// Returns current block gas limit
+pub fn gas_limit() -> U256 {
+    let first: u64;
+    let second: u64;
+    let third: u64;
+    let fourth: u64;
+    unsafe {
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u32::from(Syscall::GasLimit));
+    }
+    U256::from_limbs([first, second, third, fourth])
+}
+
+// Returns current block number
+pub fn number() -> U256 {
+    let first: u64;
+    let second: u64;
+    let third: u64;
+    let fourth: u64;
+    unsafe {
+        asm!("ecall", lateout("a0") first, lateout("a1") second, lateout("a2") third, lateout("a3") fourth, in("t0") u32::from(Syscall::Number));
+    }
+    U256::from_limbs([first, second, third, fourth])
+}

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -10,6 +10,7 @@ pub use riscv_rt::entry;
 
 mod alloc;
 pub mod types;
+pub mod block;
 
 const CALLDATA_ADDRESS: usize = 0x8000_0000;
 

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -61,9 +61,18 @@ syscalls!(
     (0x20, Keccak256, "keccak256"),
     (0x33, Caller, "caller"),
     (0x34, CallValue, "callvalue"),
+    (0x42, Timestamp, "timestamp"),
+    (0x43, Number, "number"),
+    (0x45, GasLimit, "gaslimit"),
+    (0x46, ChainId, "chainid"),
+    (0x48, BaseFee, "basefee"),
     (0x54, SLoad, "sload"),
     (0x55, SStore, "sstore"),
     (0xf1, Call, "call"),
     (0xf3, Return, "return"),
-    (0xfd, Revert, "revert")
+    (0xfd, Revert, "revert"),
+    // (0x4A, BlobBaseFee, "blobbasefee") Disabled for L2
+    // coinbase is also disabled as it is implementation specific and depends on the L2 used
+    // block.difficulty is also disabled as L2s don't have PoW security model
+    // prevrandao is not used as there is no beacon chain to provide randomness
 );

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -71,8 +71,4 @@ syscalls!(
     (0xf1, Call, "call"),
     (0xf3, Return, "return"),
     (0xfd, Revert, "revert"),
-    // (0x4A, BlobBaseFee, "blobbasefee") Disabled for L2
-    // coinbase is also disabled as it is implementation specific and depends on the L2 used
-    // block.difficulty is also disabled as L2s don't have PoW security model
-    // prevrandao is not used as there is no beacon chain to provide randomness
 );

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -297,7 +297,7 @@ fn execute_riscv(
                         emu.cpu.xregs.write(13, limbs[3]);
                     }
                     Syscall::ChainId => {
-                        let value = host.env().tx.chain_id.unwrap_or_default();
+                        let value = host.env().cfg.chain_id;
                         emu.cpu.xregs.write(10, value);
                     }
                     Syscall::GasLimit => {

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -288,6 +288,42 @@ fn execute_riscv(
                         emu.cpu.xregs.write(12, limbs[2]);
                         emu.cpu.xregs.write(13, limbs[3]);
                     }
+                    Syscall::BaseFee => {
+                        let value = host.env().block.basefee;
+                        let limbs = value.as_limbs();
+                        emu.cpu.xregs.write(10, limbs[0]);
+                        emu.cpu.xregs.write(11, limbs[1]);
+                        emu.cpu.xregs.write(12, limbs[2]);
+                        emu.cpu.xregs.write(13, limbs[3]);
+                    }
+                    Syscall::ChainId => {
+                        let value = host.env().tx.chain_id.unwrap_or_default();
+                        emu.cpu.xregs.write(10, value);
+                    }
+                    Syscall::GasLimit => {
+                        let limit = host.env().block.gas_limit;
+                        let limbs = limit.as_limbs();
+                        emu.cpu.xregs.write(10, limbs[0]);
+                        emu.cpu.xregs.write(11, limbs[1]);
+                        emu.cpu.xregs.write(12, limbs[2]);
+                        emu.cpu.xregs.write(13, limbs[3]);
+                    }
+                    Syscall::Number => {
+                        let number = host.env().block.number;
+                        let limbs = number.as_limbs();
+                        emu.cpu.xregs.write(10, limbs[0]);
+                        emu.cpu.xregs.write(11, limbs[1]);
+                        emu.cpu.xregs.write(12, limbs[2]);
+                        emu.cpu.xregs.write(13, limbs[3]);
+                    }
+                    Syscall::Timestamp => {
+                        let timestamp = host.env().block.timestamp;
+                        let limbs = timestamp.as_limbs();
+                        emu.cpu.xregs.write(10, limbs[0]);
+                        emu.cpu.xregs.write(11, limbs[1]);
+                        emu.cpu.xregs.write(12, limbs[2]);
+                        emu.cpu.xregs.write(13, limbs[3]);
+                    }
                 }
             }
             _ => {


### PR DESCRIPTION
This PR adds support for the following `block.*` functions: `timestamp`, `number`, `gaslimit`, `chainid` and `basefee`.

The remaining functions do not seem to fit in an L2 environment:
- `blobbasefee` as L2s do not serve blobs
- `coinbase` as it is implementation specific and depends on the L2 used
- `difficulty` as L2s don't have a PoW security model
- `prevrandao` as there is no beacon chain to provide randomness

Do we want to provide default values for them (like OP Stack) or not support them altogether to reduce confusion for devs? 
cc @leonardoalt @gakonst 

Also block-specific methods have been tucked into their own module so devs can access them more explicitly like so `block::gas_limit()`, `block::chain_id()`, etc