### PR TITLE
Crude gas metering

### DIFF
--- a/eth-riscv-interpreter/Cargo.toml
+++ b/eth-riscv-interpreter/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rvemu = { git = "https://github.com/lvella/rvemu.git" }
+rvemu = { git="https://github.com/0xRampey/rvemu.git", branch="count_instr" }
 
 thiserror.workspace = true
 

--- a/eth-riscv-interpreter/Cargo.toml
+++ b/eth-riscv-interpreter/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rvemu = { git="https://github.com/0xRampey/rvemu.git", branch="count_instr" }
+rvemu = { git="https://github.com/r55-eth/rvemu.git"}
 
 thiserror.workspace = true
 

--- a/r55/Cargo.toml
+++ b/r55/Cargo.toml
@@ -10,7 +10,7 @@ eth-riscv-interpreter.workspace = true
 eth-riscv-syscalls.workspace = true
 
 revm = { version = "9.0.0", features = ["std"] }
-rvemu = { git="https://github.com/0xRampey/rvemu.git", branch="count_instr" }
+rvemu = { git="https://github.com/r55-eth/rvemu.git" }
 
 alloy-core = "0.7.4"
 alloy-sol-types = "0.7.4"

--- a/r55/Cargo.toml
+++ b/r55/Cargo.toml
@@ -10,7 +10,7 @@ eth-riscv-interpreter.workspace = true
 eth-riscv-syscalls.workspace = true
 
 revm = { version = "9.0.0", features = ["std"] }
-rvemu = { git = "https://github.com/lvella/rvemu.git" }
+rvemu = { git="https://github.com/0xRampey/rvemu.git", branch="count_instr" }
 
 alloy-core = "0.7.4"
 alloy-sol-types = "0.7.4"

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -486,7 +486,7 @@ fn r55_gas_used(inst_count: &BTreeMap<String, u64>) -> u64 {
 
     // This is the minimum 'gas used' to ABI decode 'empty' calldata into Rust type arguments. Real calldata will take more gas.
     // Internalising this would focus gas metering more on the function logic
-    let base_cost = 9_175_538;
+    let abi_decode_cost = 9_175_538;
 
-    total_cost - base_cost
+    total_cost - abi_decode_cost
 }

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -191,7 +191,7 @@ fn execute_riscv(
                         let ret_offset: u64 = emu.cpu.xregs.read(10);
                         let ret_size: u64 = emu.cpu.xregs.read(11);
 
-                        let r55_gas = r55_gas_used(&emu.cpu.inst_counter.clone());
+                        let r55_gas = r55_gas_used(&emu.cpu.inst_counter);
                         let data_bytes = dram_slice(emu, ret_offset, ret_size)?;
 
                         let total_cost = r55_gas + evm_gas;
@@ -441,7 +441,7 @@ fn execute_riscv(
                 }
             }
             _ => {
-                let total_cost = r55_gas_used(&emu.cpu.inst_counter.clone()) + evm_gas;
+                let total_cost = r55_gas_used(&emu.cpu.inst_counter) + evm_gas;
                 return return_revert(interpreter, total_cost);
             }
         }
@@ -463,9 +463,9 @@ fn dram_slice(emu: &mut Emulator, ret_offset: u64, ret_size: u64) -> Result<&mut
 fn r55_gas_used(inst_count: &BTreeMap<String, u64>) -> u64 {
     let total_cost = inst_count
         .iter()
-        .map(|(instr_name, count)|
+        .map(|(inst_name, count)|
             // Gas cost = number of instructions * cycles per instruction
-            match instr_name.as_str() {
+            match inst_name.as_str() {
                 // Gas map to approximate cost of each instruction
                 // References:
                 // http://ithare.com/infographics-operation-costs-in-cpu-clock-cycles/
@@ -484,7 +484,7 @@ fn r55_gas_used(inst_count: &BTreeMap<String, u64>) -> u64 {
         })
         .sum::<u64>();
 
-    // This is the minimum "gas used" to ABI decode 'empty' calldata into Rust type arguments. Real calldata will take more gas.
+    // This is the minimum 'gas used' to ABI decode 'empty' calldata into Rust type arguments. Real calldata will take more gas.
     // Internalising this would focus gas metering more on the function logic
     let base_cost = 9_175_538;
 


### PR DESCRIPTION
explores #17 

Some notes:
- ABI decoding tx calldata from bytes to Rust types is the most expensive operation, running into millions of RISC-V opcodes executed.
- An ERC20 transfer takes 19K gas with the current gas model  (incl sload, sstore)
- `mint` => 11.4K, `balance` => 6K, `approve` => 11.2K 