### PR TITLE
Update ELF execution test

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Nothing has to be changed in how transactions are handled or created.
 - [R55 Ethereum Runtime](https://github.com/leonardoalt/r55/tree/main/eth-riscv-runtime)
 - [R55 Compiler](https://github.com/leonardoalt/r55/tree/main/r55)
 
+# Prerequisites
+
+## macOS
+
+```shell
+brew install riscv-gnu-toolchain gettext
+```
+
 # Test
 
 The [R55](https://github.com/leonardoalt/r55/tree/main/r55) crate has a binary

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ running two transactions on it, first a `mint` then a `balance_of` check.
 You'll need to install Rust's RISCV toolchain:
 
 ```console
-$ rustup install nightly-2024-02-01-x86_64-unknown-linux-gnu  
+$ rustup install nightly-2024-02-01-x86_64-unknown-linux-gnu
 ```
 
 Now run:


### PR DESCRIPTION
Before taking #16, I was making sure if current existing tests run well.

I found out that without prerequisites installed, `make` command won't work to generate runtime ELF which is necessary for `test_execute_elf` test, so I added prerequisites in the doc macOS.

I also thought having to run `make` command for a unit test is not good, so I added logic to run `make` in the test setup if runtime ELF is missing.

TODO: add prerequisite for linux as well.