### PR TITLE
Fix Transfer Event for `mint` of ERC20

### DIFF
--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -95,7 +95,11 @@ impl ERC20 {
 
         let to_balance = self.balances.read(to);
         self.balances.write(to, to_balance + value);
-        log::emit(Transfer::new(0, to, value));
+        log::emit(Transfer::new(
+            address!("0000000000000000000000000000000000000000"),
+            to,
+            value,
+        ));
         true
     }
 }

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -6,7 +6,7 @@ use core::default::Default;
 use contract_derive::{contract, payable, Event};
 use eth_riscv_runtime::types::Mapping;
 
-use alloy_core::primitives::{Address, address, U256};
+use alloy_core::primitives::{address, Address, U256};
 
 extern crate alloc;
 use alloc::string::String;
@@ -27,7 +27,7 @@ pub struct Transfer {
     pub from: Address,
     #[indexed]
     pub to: Address,
-    pub value: u64
+    pub value: u64,
 }
 
 #[derive(Event)]
@@ -36,7 +36,7 @@ pub struct Mint {
     pub from: Address,
     #[indexed]
     pub to: Address,
-    pub value: u64
+    pub value: u64,
 }
 
 #[contract]
@@ -72,7 +72,9 @@ impl ERC20 {
         let sender_balance = self.balances.read(sender);
         let recipient_balance = self.balances.read(recipient);
 
-        self.allowances.read(sender).write(msg_sender(), allowance - amount);
+        self.allowances
+            .read(sender)
+            .write(msg_sender(), allowance - amount);
         self.balances.write(sender, sender_balance - amount);
         self.balances.write(recipient, recipient_balance + amount);
 

--- a/r55/src/main.rs
+++ b/r55/src/main.rs
@@ -8,12 +8,12 @@ use std::fs::File;
 use std::io::Read;
 use std::process::Command;
 
+use alloy_core::hex;
 use alloy_sol_types::SolValue;
 use revm::{
     primitives::{address, keccak256, ruint::Uint, AccountInfo, Address, Bytecode, Bytes, U256},
     InMemoryDB,
 };
-use alloy_core::hex;
 
 fn compile_runtime(path: &str) -> eyre::Result<Vec<u8>> {
     println!("Compiling runtime: {}", path);
@@ -244,7 +244,7 @@ fn test_transfer_logs() -> eyre::Result<()> {
     let mut calldata_mint = (alice, 100u64).abi_encode();
     let mut complete_mint_calldata = selector_mint.to_vec();
     complete_mint_calldata.append(&mut calldata_mint);
-    
+
     let mint_result = run_tx(&mut db, &CONTRACT_ADDR, complete_mint_calldata)?;
     println!("Mint result status: {}", mint_result.status);
 
@@ -258,9 +258,9 @@ fn test_transfer_logs() -> eyre::Result<()> {
     let mut calldata_transfer = (bob, 50u64).abi_encode();
     let mut complete_transfer_calldata = selector_transfer.to_vec();
     complete_transfer_calldata.append(&mut calldata_transfer);
-    
+
     let transfer_result = run_tx(&mut db, &CONTRACT_ADDR, complete_transfer_calldata)?;
-    
+
     println!("\nActual Transfer Log:");
     if let Some(log) = transfer_result.logs.first() {
         let topics = log.data.topics();
@@ -270,10 +270,9 @@ fn test_transfer_logs() -> eyre::Result<()> {
         let amount = u64::from_be_bytes(log.data.data[24..32].try_into().unwrap());
         println!("- Amount: {} tokens", amount);
     }
-    
+
     Ok(())
 }
-
 
 fn main() -> eyre::Result<()> {
     test_runtime_from_binary()?;


### PR DESCRIPTION
The first field of Transfer Event, `from`, expects `Address` type.

Before the fix, integer was given, so `cargo run` failed.
