### PR TITLE
chore: mutable contracts + storable evm words

### DIFF
--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -224,11 +224,11 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #emit_helper
         impl Contract for #struct_name {
-            fn call(&self) {
+            fn call(&mut self) {
                 self.call_with_data(&msg_data());
             }
 
-            fn call_with_data(&self, calldata: &[u8]) {
+            fn call_with_data(&mut self, calldata: &[u8]) {
                 let selector = u32::from_be_bytes([calldata[0], calldata[1], calldata[2], calldata[3]]);
                 let calldata = &calldata[4..];
 
@@ -244,7 +244,7 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[eth_riscv_runtime::entry]
         fn main() -> !
         {
-            let contract = #struct_name::default();
+            let mut contract = #struct_name::default();
             contract.call();
             eth_riscv_runtime::return_riscv(0, 0)
         }

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -4,7 +4,7 @@
 use core::default::Default;
 
 use contract_derive::{contract, payable, Event};
-use eth_riscv_runtime::types::Mapping;
+use eth_riscv_runtime::types::{Mapping, Word};
 
 use alloy_core::primitives::{address, Address, U256};
 
@@ -15,7 +15,7 @@ use alloc::string::String;
 pub struct ERC20 {
     balances: Mapping<Address, u64>,
     allowances: Mapping<Address, Mapping<Address, u64>>,
-    total_supply: U256,
+    total_supply: Word<U256>,
     name: String,
     symbol: String,
     decimals: u8,
@@ -45,7 +45,7 @@ impl ERC20 {
         self.balances.read(owner)
     }
 
-    pub fn transfer(&self, to: Address, value: u64) -> bool {
+    pub fn transfer(&mut self, to: Address, value: u64) -> bool {
         let from = msg_sender();
         let from_balance = self.balances.read(from);
         let to_balance = self.balances.read(to);
@@ -61,13 +61,13 @@ impl ERC20 {
         true
     }
 
-    pub fn approve(&self, spender: Address, value: u64) -> bool {
-        let spender_allowances = self.allowances.read(msg_sender());
+    pub fn approve(&mut self, spender: Address, value: u64) -> bool {
+        let mut spender_allowances = self.allowances.read(msg_sender());
         spender_allowances.write(spender, value);
         true
     }
 
-    pub fn transfer_from(&self, sender: Address, recipient: Address, amount: u64) -> bool {
+    pub fn transfer_from(&mut self, sender: Address, recipient: Address, amount: u64) -> bool {
         let allowance = self.allowances.read(sender).read(msg_sender());
         let sender_balance = self.balances.read(sender);
         let recipient_balance = self.balances.read(recipient);
@@ -82,7 +82,7 @@ impl ERC20 {
     }
 
     pub fn total_supply(&self) -> U256 {
-        self.total_supply
+        self.total_supply.read()
     }
 
     pub fn allowance(&self, owner: Address, spender: Address) -> u64 {
@@ -90,11 +90,15 @@ impl ERC20 {
     }
 
     #[payable]
-    pub fn mint(&self, to: Address, value: u64) -> bool {
+    pub fn mint(&mut self, to: Address, value: u64) -> bool {
         let owner = msg_sender();
 
         let to_balance = self.balances.read(to);
         self.balances.write(to, to_balance + value);
+
+        let prev_supply = self.total_supply.read();
+        self.total_supply.write(prev_supply + U256::from(value));
+
         log::emit(Transfer::new(
             address!("0000000000000000000000000000000000000000"),
             to,

--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -22,8 +22,8 @@ pub use call::call_contract;
 const CALLDATA_ADDRESS: usize = 0x8000_0000;
 
 pub trait Contract {
-    fn call(&self);
-    fn call_with_data(&self, calldata: &[u8]);
+    fn call(&mut self);
+    fn call_with_data(&mut self, calldata: &[u8]);
 }
 
 pub unsafe fn slice_from_raw_parts(address: usize, length: usize) -> &'static [u8] {

--- a/eth-riscv-runtime/src/types/mapping.rs
+++ b/eth-riscv-runtime/src/types/mapping.rs
@@ -1,7 +1,7 @@
 use core::default::Default;
 use core::marker::PhantomData;
 
-use crate::*;
+use super::*;
 
 use alloy_sol_types::{SolType, SolValue};
 
@@ -13,29 +13,6 @@ use alloc::vec::Vec;
 pub struct Mapping<K, V> {
     id: u64,
     pd: PhantomData<(K, V)>,
-}
-
-/// A trait for types that can be read from and written to storage slots
-pub trait StorageStorable {
-    fn read(key: u64) -> Self;
-    fn write(&self, key: u64);
-}
-
-impl<V> StorageStorable for V
-where
-    V: SolValue + core::convert::From<<<V as SolValue>::SolType as SolType>::RustType>,
-{
-    fn read(encoded_key: u64) -> Self {
-        let bytes: [u8; 32] = sload(encoded_key).to_be_bytes();
-        Self::abi_decode(&bytes, false).unwrap_or_else(|_| revert())
-    }
-
-    fn write(&self, key: u64) {
-        let bytes = self.abi_encode();
-        let mut padded = [0u8; 32];
-        padded[..bytes.len()].copy_from_slice(&bytes);
-        sstore(key, U256::from_be_bytes(padded));
-    }
 }
 
 impl<K: SolValue, V: StorageStorable> StorageStorable for Mapping<K, V> {
@@ -77,7 +54,7 @@ impl<K: SolValue, V: StorageStorable> Mapping<K, V> {
         V::read(self.encode_key(key))
     }
 
-    pub fn write(&self, key: K, value: V) {
+    pub fn write(&mut self, key: K, value: V) {
         value.write(self.encode_key(key));
     }
 }

--- a/eth-riscv-runtime/src/types/mod.rs
+++ b/eth-riscv-runtime/src/types/mod.rs
@@ -1,0 +1,31 @@
+mod mapping;
+pub use mapping::Mapping;
+
+mod word;
+pub use word::Word;
+
+use crate::*;
+use alloy_sol_types::{SolType, SolValue};
+
+/// A trait for types that can be read from and written to storage slots
+pub trait StorageStorable {
+    fn read(key: u64) -> Self;
+    fn write(&self, key: u64);
+}
+
+impl<V> StorageStorable for V
+where
+    V: SolValue + core::convert::From<<<V as SolValue>::SolType as SolType>::RustType>,
+{
+    fn read(encoded_key: u64) -> Self {
+        let bytes: [u8; 32] = sload(encoded_key).to_be_bytes();
+        Self::abi_decode(&bytes, false).unwrap_or_else(|_| revert())
+    }
+
+    fn write(&self, key: u64) {
+        let bytes = self.abi_encode();
+        let mut padded = [0u8; 32];
+        padded[..bytes.len()].copy_from_slice(&bytes);
+        sstore(key, U256::from_be_bytes(padded));
+    }
+}

--- a/eth-riscv-runtime/src/types/word.rs
+++ b/eth-riscv-runtime/src/types/word.rs
@@ -1,0 +1,21 @@
+use core::default::Default;
+use core::marker::PhantomData;
+
+use super::*;
+
+/// Implements `StorageStorable` EVM words
+#[derive(Default)]
+pub struct Word<V> {
+    slot: u64,
+    value: PhantomData<V>,
+}
+
+impl<V: StorageStorable> Word<V> {
+    pub fn read(&self) -> V {
+        V::read(self.slot)
+    }
+
+    pub fn write(&mut self, value: V) {
+        value.write(self.slot)
+    }
+}

--- a/r55/src/lib.rs
+++ b/r55/src/lib.rs
@@ -131,6 +131,7 @@ mod tests {
         let bytecode = compile_with_prefix(compile_runtime, ERC20_PATH).unwrap();
         add_contract_to_db(&mut db, CONTRACT_ADDR, bytecode);
 
+        let selector_total_supply = get_selector_from_sig("total_supply");
         let selector_balance = get_selector_from_sig("balance_of");
         let selector_mint = get_selector_from_sig("mint");
         let selector_transfer = get_selector_from_sig("transfer");
@@ -178,6 +179,14 @@ mod tests {
             alice_balance.output,
             Uint::from(42).abi_encode(),
             "Incorrect balance"
+        );
+
+        // Check total supply
+        let total_supply = run_tx(&mut db, &CONTRACT_ADDR, selector_total_supply.to_vec()).unwrap();
+        assert_eq!(
+            total_supply.output,
+            Uint::from(42).abi_encode(),
+            "Incorrect total supply"
         );
 
         // Transfer 21 tokens from Alice to Bob

--- a/r55/tests/e2e.rs
+++ b/r55/tests/e2e.rs
@@ -28,6 +28,7 @@ fn erc20() {
     let selector_balance = get_selector_from_sig("balance_of");
     let selector_x_balance = get_selector_from_sig("x_balance_of");
     let selector_mint = get_selector_from_sig("mint");
+    let total_supply = get_selector_from_sig("total_supply");
     let alice: Address = address!("000000000000000000000000000000000000000A");
     let value_mint: u64 = 42;
     let mut calldata_balance = alice.abi_encode();
@@ -53,6 +54,18 @@ fn erc20() {
         Bytes::from(complete_calldata_mint.clone())
     );
     match run_tx(&mut db, &addr1, complete_calldata_mint.clone()) {
+        Ok(res) => info!("Success! {}", res),
+        Err(e) => {
+            error!("Error when executing tx! {:#?}", e);
+            panic!()
+        }
+    };
+
+    info!("----------------------------------------------------------");
+    info!("-- TOTAL SUPPLY -------------------------------------------");
+    info!("----------------------------------------------------------");
+    debug!("Tx Calldata:\n> {:#?}", Bytes::from(total_supply.to_vec()));
+    match run_tx(&mut db, &addr1, total_supply.to_vec()) {
         Ok(res) => info!("Success! {}", res),
         Err(e) => {
             error!("Error when executing tx! {:#?}", e);


### PR DESCRIPTION
this PoC:
- introduces `Word`, a new `StorageStorable` type to store evm words
- modifies the `Contract` and `Mapping` apis, to enforce mutability checks   >>   now, if users try to implement a fn that writes into storage and don't declare it as mutable, they will get a compiler error

enhancements that i have in mind if this direction is desirable:
- interface adoption of "mutability awareness"
- allow usage of `pub` keyword for contract attributes, so that the `contract` macro auto-generates a getter fn
- implement std ops like `Add` or `AddAssign` so that users can simply do `self.total_supply += value`
- implement a new `StorageStorable` for strings